### PR TITLE
Update supported AI models and add version constraints

### DIFF
--- a/ai_player.py
+++ b/ai_player.py
@@ -675,6 +675,7 @@ SUPPORTED_MODELS = {
     "gemini-2.5-flash-lite": "gemini",
     "gemini-3.1-pro-preview": "gemini",
     "gemini-3-flash-preview": "gemini",
+    "gemini-3.1-flash-lite": "gemini",
     "gemini-3.1-flash-lite-preview": "gemini",
     # Gemini (legacy)
     "gemini-2.0-flash": "gemini",

--- a/ai_player.py
+++ b/ai_player.py
@@ -682,12 +682,15 @@ SUPPORTED_MODELS = {
     "gemini-2.5-pro-preview-06-05": "gemini",
     "gemini-2.5-flash-preview-05-20": "gemini",
     # OpenAI (latest)
-    "gpt-4.1": "openai",
-    "gpt-4.1-mini": "openai",
+    "gpt-5.4": "openai",
+    "gpt-5.4-pro": "openai",
+    "gpt-5-mini": "openai",
     "o3": "openai",
     "o3-pro": "openai",
     "o4-mini": "openai",
     # OpenAI (legacy)
+    "gpt-4.1": "openai",
+    "gpt-4.1-mini": "openai",
     "o3-mini": "openai",
     "o1": "openai",
     "o1-pro": "openai",

--- a/ai_player.py
+++ b/ai_player.py
@@ -669,32 +669,41 @@ class AnthropicPlayer(BaseAIPlayer):
 
 # --- Model Provider Mapping --- 
 SUPPORTED_MODELS = {
-    # Gemini
-    "gemini-1.5-pro": "gemini",
-    "gemini-1.5-flash": "gemini",
-    "gemini-1.5-flash-8b": "gemini",
+    # Gemini (latest)
+    "gemini-2.5-pro": "gemini",
+    "gemini-2.5-flash": "gemini",
+    "gemini-2.5-flash-lite": "gemini",
+    "gemini-3.1-pro-preview": "gemini",
+    "gemini-3-flash-preview": "gemini",
+    "gemini-3.1-flash-lite-preview": "gemini",
+    # Gemini (legacy)
     "gemini-2.0-flash": "gemini",
     "gemini-2.0-flash-lite": "gemini",
-    "gemini-2.5-pro-preview-05-06": "gemini",
     "gemini-2.5-pro-preview-06-05": "gemini",
-    "gemini-2.5-pro-exp-03-25": "gemini",
     "gemini-2.5-flash-preview-05-20": "gemini",
-    # OpenAI
-    "o4-mini": "openai",
-    "o3-mini": "openai",
-    "o1-mini": "openai",
-    "o1-pro": "openai",
-    "o1": "openai",
+    # OpenAI (latest)
+    "gpt-4.1": "openai",
+    "gpt-4.1-mini": "openai",
     "o3": "openai",
-    "gpt-4o-mini": "openai",
+    "o3-pro": "openai",
+    "o4-mini": "openai",
+    # OpenAI (legacy)
+    "o3-mini": "openai",
+    "o1": "openai",
+    "o1-pro": "openai",
     "gpt-4o": "openai",
+    "gpt-4o-mini": "openai",
     "gpt-4.5-preview": "openai",
-    # Anthropic
+    # Anthropic (latest)
+    "claude-opus-4-6": "anthropic",
+    "claude-sonnet-4-6": "anthropic",
+    "claude-haiku-4-5-20251001": "anthropic",
+    # Anthropic (legacy)
     "claude-3-7-sonnet-20250219": "anthropic",
-    "claude-3-5-sonnet-20241022": "anthropic",
-    "claude-3-5-haiku-20241022": "anthropic",
-    "claude-3-opus-20240229": "anthropic",
     "claude-sonnet-4-20250514": "anthropic",
+    "claude-3-5-haiku-20241022": "anthropic",
+    "claude-3-5-sonnet-20241022": "anthropic",
+    "claude-3-opus-20240229": "anthropic",
 }
 
 # --- Factory Function (Updated) --- 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 requests
-google-generativeai
+google-generativeai>=0.8.0
 atproto
 python-dotenv
 schedule
-openai
-anthropic 
+openai>=2.0.0
+anthropic>=0.40.0


### PR DESCRIPTION
## Summary
Updated the supported models mapping to reflect the latest versions of Gemini, OpenAI, and Anthropic models, while organizing them by release status (latest vs. legacy). Also added minimum version constraints to dependencies.

## Key Changes
- **Gemini models**: Replaced 1.5 series with 2.5 and 3.x series as latest, moved 2.0 series to legacy section
- **OpenAI models**: Added new GPT-5.x and O3 series models as latest, reorganized existing models into legacy section
- **Anthropic models**: Added new Claude Opus 4.6, Sonnet 4.6, and Haiku 4.5 models as latest, moved older versions to legacy section
- **Model organization**: Grouped models by provider and release status (latest/legacy) with clear comments for maintainability
- **Dependencies**: Added minimum version constraints to `google-generativeai>=0.8.0`, `openai>=2.0.0`, and `anthropic>=0.40.0`

## Implementation Details
The model mapping now uses a two-tier organization within each provider to clearly distinguish between current production models and legacy/deprecated versions. This improves code clarity and makes it easier to identify which models should be preferred for new implementations.

https://claude.ai/code/session_01VNTyBEqjLDMKEEKd29uKnw